### PR TITLE
Implement simple We Eat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# Home-Assistant-We-eat
+# Home Assistant We Eat
+
+This custom integration shows a random recipe from a configurable list. The recipe updates every day at **12:00** and **19:00** for lunch and dinner.
+
+## Installation
+
+1. Copy the `custom_components/we_eat` folder to your Home Assistant `config/custom_components` directory.
+2. Copy `we_eat_card.js` to your `www` folder and add the resource to your Lovelace configuration.
+
+## Configuration
+
+Add to your `configuration.yaml`:
+
+```yaml
+we_eat:
+  recipes:
+    - Spaghetti
+    - Pizza
+    - Risotto
+```
+
+Reload Home Assistant. A sensor named `sensor.we_eat_menu` will be created.
+
+Use the provided services `we_eat.add_recipe` and `we_eat.remove_recipe` to manage recipes.
+
+Add the custom card to your dashboard:
+
+```yaml
+type: 'custom:we-eat-card'
+entity: sensor.we_eat_menu
+```

--- a/custom_components/we_eat/__init__.py
+++ b/custom_components/we_eat/__init__.py
@@ -1,0 +1,63 @@
+"""We Eat custom integration for Home Assistant."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.event import async_track_time_change
+from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "we_eat"
+CONF_RECIPES = "recipes"
+
+DEFAULT_RECIPES = [
+    "Spaghetti",
+    "Pizza",
+    "Risotto",
+]
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the We Eat integration."""
+    conf = config.get(DOMAIN, {})
+    recipes = conf.get(CONF_RECIPES, DEFAULT_RECIPES)
+    hass.data[DOMAIN] = {
+        CONF_RECIPES: list(recipes),
+    }
+
+    async_load_platform(hass, "sensor", DOMAIN, {}, config)
+
+    @callback
+    def update_lunch(now: datetime) -> None:
+        _LOGGER.debug("Updating lunch recipe")
+        hass.helpers.dispatcher.async_dispatcher_send("we_eat_update")
+
+    @callback
+    def update_dinner(now: datetime) -> None:
+        _LOGGER.debug("Updating dinner recipe")
+        hass.helpers.dispatcher.async_dispatcher_send("we_eat_update")
+
+    async_track_time_change(hass, update_lunch, hour=12, minute=0, second=0)
+    async_track_time_change(hass, update_dinner, hour=19, minute=0, second=0)
+
+    async def handle_add(call: Any) -> None:
+        recipe = call.data.get("recipe")
+        if recipe:
+            hass.data[DOMAIN][CONF_RECIPES].append(recipe)
+            hass.helpers.dispatcher.async_dispatcher_send("we_eat_update")
+
+    async def handle_remove(call: Any) -> None:
+        recipe = call.data.get("recipe")
+        if recipe and recipe in hass.data[DOMAIN][CONF_RECIPES]:
+            hass.data[DOMAIN][CONF_RECIPES].remove(recipe)
+            hass.helpers.dispatcher.async_dispatcher_send("we_eat_update")
+
+    hass.services.async_register(DOMAIN, "add_recipe", handle_add)
+    hass.services.async_register(DOMAIN, "remove_recipe", handle_remove)
+
+    return True

--- a/custom_components/we_eat/manifest.json
+++ b/custom_components/we_eat/manifest.json
@@ -1,0 +1,9 @@
+{
+    "domain": "we_eat",
+    "name": "We Eat Menu",
+    "documentation": "https://github.com/example/we_eat",
+    "dependencies": [],
+    "codeowners": [],
+    "version": "0.1.0",
+    "requirements": []
+}

--- a/custom_components/we_eat/sensor.py
+++ b/custom_components/we_eat/sensor.py
@@ -1,0 +1,43 @@
+"""Sensor platform for We Eat."""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import DOMAIN, CONF_RECIPES
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the We Eat sensor."""
+    sensor = WeEatSensor(hass.data[DOMAIN][CONF_RECIPES])
+    async_add_entities([sensor])
+
+class WeEatSensor(SensorEntity):
+    """Representation of the We Eat sensor."""
+
+    def __init__(self, recipes: list[str]) -> None:
+        self._recipes = recipes
+        self._state = random.choice(recipes)
+
+    async def async_added_to_hass(self) -> None:
+        async_dispatcher_connect(self.hass, "we_eat_update", self.pick_random_recipe)
+
+    @property
+    def name(self) -> str:
+        return "We Eat Menu"
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {"recipes": self._recipes}
+
+    def pick_random_recipe(self) -> None:
+        if self._recipes:
+            self._state = random.choice(self._recipes)
+        self.schedule_update_ha_state()

--- a/custom_components/we_eat/services.yaml
+++ b/custom_components/we_eat/services.yaml
@@ -1,0 +1,12 @@
+add_recipe:
+  description: "Add a recipe to the menu list."
+  fields:
+    recipe:
+      description: "Name of the recipe"
+      example: "Lasagne"
+remove_recipe:
+  description: "Remove a recipe from the menu list."
+  fields:
+    recipe:
+      description: "Name of the recipe"
+      example: "Pizza"

--- a/we_eat_card.js
+++ b/we_eat_card.js
@@ -1,0 +1,33 @@
+class WeEatCard extends HTMLElement {
+  set hass(hass) {
+    const entity = hass.states[this.config.entity];
+    if (!entity) return;
+    if (!this.content) {
+      this.innerHTML = `
+        <ha-card header="We Eat">
+          <div class="card-content"></div>
+        </ha-card>`;
+      this.content = this.querySelector(".card-content");
+    }
+    this.content.innerHTML = entity.state;
+  }
+
+  setConfig(config) {
+    if (!config.entity) {
+      throw new Error("Entity is required");
+    }
+    this.config = config;
+  }
+
+  static getConfigElement() {
+    return document.createElement("hui-entities-card-editor");
+  }
+}
+customElements.define('we-eat-card', WeEatCard);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: 'we-eat-card',
+  name: 'We Eat Card',
+  description: 'Shows random recipe from We Eat sensor.',
+});


### PR DESCRIPTION
## Summary
- implement `we_eat` custom integration
- add sensor entity that updates at 12:00 and 19:00 with a random recipe
- expose services to add and remove recipes
- provide a minimal Lovelace card
- document integration usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849f0d57f48832c9f4a4dadb671d7e0